### PR TITLE
More txn tests

### DIFF
--- a/src/backend/concurrency/pessimistic_transaction_manager.cpp
+++ b/src/backend/concurrency/pessimistic_transaction_manager.cpp
@@ -167,7 +167,17 @@ bool PessimisticTransactionManager::PerformRead(const oid_t &tile_group_id,
   auto tile_group = manager.GetTileGroup(tile_group_id);
   auto tile_group_header = tile_group->GetHeader();
 
-  if (IsOwner(tile_group.get(), tuple_id)) return true;
+  auto &rw_set = current_txn->GetRWSet();
+  auto tuple_map = rw_set.find(tile_group_id);
+  if (tuple_map != rw_set.end()) {
+    if (tuple_map->second.find(tuple_id) != tuple_map->second.end()) {
+      // It was already accessed, don't acquire read lock again
+      return true;
+    }
+  }
+
+  if (IsOwner(tile_group.get(), tuple_id))
+    return true;
 
   // Try to acquire read lock.
 
@@ -203,7 +213,7 @@ bool PessimisticTransactionManager::PerformRead(const oid_t &tile_group_id,
 bool PessimisticTransactionManager::PerformUpdate(
     const oid_t &tile_group_id, const oid_t &tuple_id,
     const ItemPointer &new_location) {
-  LOG_INFO("Performing Write");
+  LOG_INFO("Performing Write %lu %lu", tile_group_id, tuple_id);
 
   auto &manager = catalog::Manager::GetInstance();
   auto tile_group = manager.GetTileGroup(tile_group_id);

--- a/tests/concurrency/isolation_level_test.cpp
+++ b/tests/concurrency/isolation_level_test.cpp
@@ -23,8 +23,8 @@ namespace test {
 
 class IsolationLevelTest : public PelotonTest {};
 
-static std::vector<ConcurrencyType> TEST_TYPES = {CONCURRENCY_TYPE_OCC
-                                                  };
+static std::vector<ConcurrencyType> TEST_TYPES = {CONCURRENCY_TYPE_OCC,
+                                                  CONCURRENCY_TYPE_2PL};
 
 void DirtyWriteTest() {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/tests/concurrency/transaction_test.cpp
+++ b/tests/concurrency/transaction_test.cpp
@@ -63,10 +63,10 @@ TEST_F(TransactionTests, AbortTest) {
         TransactionTestsUtil::CreateTable());
     {
       TransactionScheduler scheduler(2, table.get(), &txn_manager);
-      scheduler.AddUpdate(0, 0, 100);
-      scheduler.AddAbort(0);
-      scheduler.AddRead(1, 0);
-      scheduler.AddCommit(1);
+      scheduler.Txn(0).Update(0, 100);
+      scheduler.Txn(0).Abort();
+      scheduler.Txn(1).Read(0);
+      scheduler.Txn(1).Commit();
 
       scheduler.Run();
 
@@ -78,9 +78,9 @@ TEST_F(TransactionTests, AbortTest) {
     {
       TransactionScheduler scheduler(2, table.get(), &txn_manager);
       // scheduler.AddInsert(0, 100, 0);
-      scheduler.AddAbort(0);
-      scheduler.AddRead(1, 100);
-      scheduler.AddCommit(1);
+      scheduler.Txn(0).Abort();
+      scheduler.Txn(1).Read(1);
+      scheduler.Txn(1).Commit();
 
       scheduler.Run();
       EXPECT_EQ(RESULT_ABORTED, scheduler.schedules[0].txn_result);

--- a/tests/concurrency/transaction_test.cpp
+++ b/tests/concurrency/transaction_test.cpp
@@ -61,28 +61,35 @@ TEST_F(TransactionTests, SingleTransactionTest) {
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     std::unique_ptr<storage::DataTable> table(
         TransactionTestsUtil::CreateTable());
-    // read, read, read, read, update, read
+    // read, read, read, read, update, read, read not exist
+    // another txn read
     {
-      TransactionScheduler scheduler(1, table.get(), &txn_manager);
+      TransactionScheduler scheduler(2, table.get(), &txn_manager);
       scheduler.Txn(0).Read(0);
       scheduler.Txn(0).Read(0);
       scheduler.Txn(0).Read(0);
       scheduler.Txn(0).Read(0);
       scheduler.Txn(0).Update(0, 1);
       scheduler.Txn(0).Read(0);
+      scheduler.Txn(0).Read(100);
       scheduler.Txn(0).Commit();
+      scheduler.Txn(1).Read(0);
+      scheduler.Txn(1).Commit();
 
       scheduler.Run();
 
       EXPECT_EQ(RESULT_SUCCESS, scheduler.schedules[0].txn_result);
+      EXPECT_EQ(RESULT_SUCCESS, scheduler.schedules[1].txn_result);
       EXPECT_EQ(0, scheduler.schedules[0].results[0]);
       EXPECT_EQ(0, scheduler.schedules[0].results[1]);
       EXPECT_EQ(0, scheduler.schedules[0].results[2]);
       EXPECT_EQ(0, scheduler.schedules[0].results[3]);
       EXPECT_EQ(1, scheduler.schedules[0].results[4]);
+      EXPECT_EQ(-1, scheduler.schedules[0].results[5]);
+      EXPECT_EQ(1, scheduler.schedules[1].results[0]);
     }
 
-    // update, update, update, update
+    // update, update, update, update, read
     {
       TransactionScheduler scheduler(1, table.get(), &txn_manager);
       scheduler.Txn(0).Update(0, 1);
@@ -96,6 +103,55 @@ TEST_F(TransactionTests, SingleTransactionTest) {
 
       EXPECT_EQ(RESULT_SUCCESS, scheduler.schedules[0].txn_result);
       EXPECT_EQ(4, scheduler.schedules[0].results[0]);
+    }
+
+    // delete not exist, delete exist, read deleted, update deleted,
+    // read deleted, insert back, update inserted, read newly updated
+    {
+      TransactionScheduler scheduler(1, table.get(), &txn_manager);
+
+      scheduler.Txn(0).Delete(100);
+      scheduler.Txn(0).Delete(0);
+      scheduler.Txn(0).Read(0);
+      scheduler.Txn(0).Update(0, 1);
+      scheduler.Txn(0).Read(0);
+      scheduler.Txn(0).Insert(0, 2);
+      scheduler.Txn(0).Update(0, 3);
+      scheduler.Txn(0).Read(0);
+      scheduler.Txn(0).Commit();
+
+      scheduler.Run();
+
+      EXPECT_EQ(RESULT_SUCCESS, scheduler.schedules[0].txn_result);
+      EXPECT_EQ(-1, scheduler.schedules[0].results[0]);
+      EXPECT_EQ(-1, scheduler.schedules[0].results[1]);
+      EXPECT_EQ(3, scheduler.schedules[0].results[2]);
+    }
+
+    // insert, delete inserted, read deleted, insert again, delete again
+    // read deleted, insert again, read inserted, update inserted, read updated
+    {
+      TransactionScheduler scheduler(1, table.get(), &txn_manager);
+
+      scheduler.Txn(0).Insert(1000, 0);
+      scheduler.Txn(0).Delete(1000);
+      scheduler.Txn(0).Read(1000);
+      scheduler.Txn(0).Insert(1000, 1);
+      scheduler.Txn(0).Delete(1000);
+      scheduler.Txn(0).Read(1000);
+      scheduler.Txn(0).Insert(1000, 2);
+      scheduler.Txn(0).Read(1000);
+      scheduler.Txn(0).Update(1000, 3);
+      scheduler.Txn(0).Read(1000);
+      scheduler.Txn(0).Commit();
+
+      scheduler.Run();
+
+      EXPECT_EQ(RESULT_SUCCESS, scheduler.schedules[0].txn_result);
+      EXPECT_EQ(-1, scheduler.schedules[0].results[0]);
+      EXPECT_EQ(-1, scheduler.schedules[0].results[1]);
+      EXPECT_EQ(2, scheduler.schedules[0].results[2]);
+      EXPECT_EQ(3, scheduler.schedules[0].results[3]);
     }
   }
 }

--- a/tests/concurrency/transaction_tests_util.cpp
+++ b/tests/concurrency/transaction_tests_util.cpp
@@ -50,13 +50,13 @@ storage::DataTable *TransactionTestsUtil::CreateTable() {
   // Create index on the id column
   std::vector<oid_t> key_attrs = {0};
   auto tuple_schema = table->GetSchema();
-  bool unique = true;
+  bool unique = false;
   auto key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
   key_schema->SetIndexedColumns(key_attrs);
 
   auto index_metadata = new index::IndexMetadata(
       "primary_btree_index", 1234, INDEX_TYPE_BTREE,
-      INDEX_CONSTRAINT_TYPE_PRIMARY_KEY, tuple_schema, key_schema, unique);
+      INDEX_CONSTRAINT_TYPE_DEFAULT, tuple_schema, key_schema, unique);
 
   index::Index *pkey_index = index::IndexFactory::GetInstance(index_metadata);
 

--- a/tests/concurrency/transaction_tests_util.h
+++ b/tests/concurrency/transaction_tests_util.h
@@ -248,34 +248,40 @@ class TransactionScheduler {
     }
   }
 
-  void AddInsert(int txn_id, int id, int value) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_INSERT, id, value);
-    sequence[time++] = txn_id;
-  }
-  void AddRead(int txn_id, int id) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_READ, id, 0);
-    sequence[time++] = txn_id;
-  }
-  void AddDelete(int txn_id, int id) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_DELETE, id, 0);
-    sequence[time++] = txn_id;
-  }
-  void AddUpdate(int txn_id, int id, int value) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_UPDATE, id, value);
-    sequence[time++] = txn_id;
-  }
-  void AddScan(int txn_id, int id) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_SCAN, id, 0);
-    sequence[time++] = txn_id;
-  }
-  void AddAbort(int txn_id) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_ABORT, 0, 0);
-    sequence[time++] = txn_id;
+  TransactionScheduler &Txn(int txn_id) {
+    assert(txn_id < (int)schedules.size());
+    cur_txn_id = txn_id;
+    return *this;
   }
 
-  void AddCommit(int txn_id) {
-    schedules[txn_id].operations.emplace_back(TXN_OP_COMMIT, 0, 0);
-    sequence[time++] = txn_id;
+  void Insert(int id, int value) {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_INSERT, id, value);
+    sequence[time++] = cur_txn_id;
+  }
+  void Read(int id) {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_READ, id, 0);
+    sequence[time++] = cur_txn_id;
+  }
+  void Delete(int id) {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_DELETE, id, 0);
+    sequence[time++] = cur_txn_id;
+  }
+  void Update(int id, int value) {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_UPDATE, id, value);
+    sequence[time++] = cur_txn_id;
+  }
+  void Scan(int id) {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_SCAN, id, 0);
+    sequence[time++] = cur_txn_id;
+  }
+  void Abort() {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_ABORT, 0, 0);
+    sequence[time++] = cur_txn_id;
+  }
+
+  void Commit() {
+    schedules[cur_txn_id].operations.emplace_back(TXN_OP_COMMIT, 0, 0);
+    sequence[time++] = cur_txn_id;
   }
 
   void clear() { schedules.clear(); }
@@ -286,6 +292,7 @@ class TransactionScheduler {
   std::vector<TransactionSchedule> schedules;
   std::vector<TransactionThread> tthreads;
   std::map<int, int> sequence;
+  int cur_txn_id;
 };
 }
 }


### PR DESCRIPTION
* Now can write txn schedule in test like: `scheduler.Txn(0).Insert(0, 1)`
* Add test for SI anomaly described in SSI paper
* Add more single txn test, fix repeated read bugs in 2PL