### PR TITLE
add the ConditionalInsertEntry in the index.h to deal with primary/un…

### DIFF
--- a/src/backend/index/btree_index.h
+++ b/src/backend/index/btree_index.h
@@ -47,6 +47,12 @@ class BTreeIndex : public Index {
 
   bool DeleteEntry(const storage::Tuple *key, const ItemPointer &location);
 
+  // TODO: implement this
+  bool ConditionalInsertEntry(const storage::Tuple *key __attribute__((unused)),
+                              const ItemPointer &location __attribute__((unused)),
+                              std::function<bool(const storage::Tuple *, const ItemPointer &)> predicate __attribute__((unused)))
+                              {return true;}
+
   std::vector<ItemPointer> Scan(const std::vector<Value> &values,
                                 const std::vector<oid_t> &key_column_ids,
                                 const std::vector<ExpressionType> &expr_types,

--- a/src/backend/index/bwtree_index.h
+++ b/src/backend/index/bwtree_index.h
@@ -47,6 +47,12 @@ class BWTreeIndex : public Index {
 
   bool DeleteEntry(const storage::Tuple *key, const ItemPointer &location);
 
+  // TODO: implement this
+  bool ConditionalInsertEntry(const storage::Tuple *key __attribute__((unused)),
+                              const ItemPointer &location __attribute__((unused)),
+                              std::function<bool(const storage::Tuple *, const ItemPointer &)> predicate __attribute__((unused)))
+                              {return true;}
+
   std::vector<ItemPointer> Scan(const std::vector<Value> &values,
                                 const std::vector<oid_t> &key_column_ids,
                                 const std::vector<ExpressionType> &expr_types,

--- a/src/backend/index/hash_index.h
+++ b/src/backend/index/hash_index.h
@@ -48,6 +48,12 @@ class HashIndex : public Index {
 
   bool DeleteEntry(const storage::Tuple *key, const ItemPointer &location);
 
+  // TODO: implement this
+  bool ConditionalInsertEntry(const storage::Tuple *key __attribute__((unused)),
+                              const ItemPointer &location __attribute__((unused)),
+                              std::function<bool(const storage::Tuple *, const ItemPointer &)> predicate __attribute__((unused)))
+                              {return true;}
+
   std::vector<ItemPointer> Scan(const std::vector<Value> &values,
                                 const std::vector<oid_t> &key_column_ids,
                                 const std::vector<ExpressionType> &expr_types,

--- a/src/backend/index/index.h
+++ b/src/backend/index/index.h
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include <string>
+#include <functional>
 
 #include "backend/common/printable.h"
 #include "backend/common/types.h"
@@ -121,6 +122,14 @@ class Index : public Printable {
   // delete the index entry linked to given tuple and location
   virtual bool DeleteEntry(const storage::Tuple *key,
                            const ItemPointer &location) = 0;
+
+  // First retrieve all Key-Value pairs of the given key
+  // Return false if any of those k-v pairs satisfy the predicate
+  // If not any of those k-v pair satisfy the predicate, insert the k-v pair into the index and return true.
+  // This function should be called for all primary/unique index insert
+  virtual bool ConditionalInsertEntry(const storage::Tuple *key,
+                                      const ItemPointer &location,
+                                      std::function<bool(const storage::Tuple *, const ItemPointer &)> predicate) = 0;
 
   //===--------------------------------------------------------------------===//
   // Accessors


### PR DESCRIPTION
Add a conditional insert API in the index.h base class. This API is design for insert of primary index in our MVCC implementation.

virtual bool ConditionalInsertEntry(const storage::Tuple *key,
                                      const ItemPointer &location,
                                      std::function<bool(const storage::Tuple *, const ItemPointer &)> predicate) = 0;

What it should do is:
1) Retrieval all key-value pairs that have the given key
2) Apply the predicate on these key-value pairs. If any of these pairs satisfy the predicate, return false.
3) Else, insert the given key-value pair into the index and return true.
4) step 2) and step 3) should be atomic.

And the predicate should be, under our MVCC scenario, a dirty read visibility check.

By doing this, we can handle tuple insertion/update in primary/unique indexes.
